### PR TITLE
 エラーページのルーティング修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,23 +3,23 @@ class ApplicationController < ActionController::Base
 
   #開発時は上段の記述を使用
   unless Rails.env.production?
-  #unless Rails.env.development?
-    rescue_from Exception,                      with: :render_500
-    rescue_from ActiveRecord::RecordNotFound,   with: :render_404
-    rescue_from ActionController::RoutingError, with: :render_404
-  end
-
-  def routing_error
-    raise ActionController::RoutingError, params[:path]
-  end
-
-  private
-
-  def render_404
-    render 'error/404', status: :not_found
-  end
-
-  def render_500
-    render 'error/500', status: :internal_server_error
-  end
+    #unless Rails.env.development?
+      rescue_from Exception,                      with: :render_500
+      rescue_from ActiveRecord::RecordNotFound,   with: :render_404
+      rescue_from ActionController::RoutingError, with: :render_404
+    end
+  
+    def routing_error
+      raise ActionController::RoutingError, params[:path]
+    end
+  
+    private
+  
+    def render_404
+      render 'error/404', status: :not_found
+    end
+  
+    def render_500
+      render 'error/500', status: :internal_server_error
+    end
 end

--- a/app/views/expendable_items/show.html.erb
+++ b/app/views/expendable_items/show.html.erb
@@ -1,9 +1,9 @@
 <h1 class="md:text-5xl text-3xl place-content-center text-center m-5 p-5"><%= @expendable_item.name %><%= t('.show_item') %></h1>
 <div class="container mx-auto md:border-l-2 md:border-r-2 md:border-black">
-  <div class="sm:text-lg md:text-2xl sm:p-2 md:p-5 sm:m-2 md:m-5 w-full text-center">
-    <%= image_tag @expendable_item.image.variant(resize_to_limit: [100, 100]) if @expendable_item.image.present? %>
+  <div class="sm:p-2 md:p-5 sm:m-2 md:m-5 w-full flex justify-center h-1/3">
+    <%= image_tag @expendable_item.image.variant(resize_to_limit: [300, 300]) if @expendable_item.image.present? %>
   </div>
-  <div class="sm:text-lg md:text-2xl sm:p-2 md:p-5 sm:m-2 md:m-5 w-full text-center">
+  <div class="sm:text-lg md:text-2xl pt-4 md:p-5 sm:m-2 md:m-5 w-full text-center">
     <strong><%= t('.name') %></strong>
     <%= @expendable_item.name %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,20 @@ Rails.application.routes.draw do
   end
   resources :expendable_items
 
-  get '*not_found', to: 'application#routing_error'
+
+  class ErrorAvoid
+    def initialize
+      @url = "active_storage/"
+    end
+
+    def matches?(request)
+      @url.include?(request.url)
+    end
+  end
+
+  Rails.application.routes.draw do
+    get '*not_found', to: 'application#routing_error', constraints: ErrorAvoid.new
+  end
   post '*not_found', to: 'application#routing_error'
 
   mount Sidekiq::Web, at: '/sidekiq'


### PR DESCRIPTION
- index画面などで消耗品画像が出ない問題が404errorに起因していたので、constraintsオプションを利用して修正